### PR TITLE
More Postgres support: add sqltrace and fix text type data loading

### DIFF
--- a/lib/GenTest/App/Gendata.pm
+++ b/lib/GenTest/App/Gendata.pm
@@ -595,6 +595,9 @@ sub run {
                     if ($field->[FIELD_TYPE] =~ m{date|time|year}sio) {
                         $value_type = DATA_TEMPORAL;
                         $quote = 1;
+                    } elsif ($executor->type == DB_POSTGRES and $field->[FIELD_TYPE] eq 'text') {
+                        $value_type = DATA_STRING;
+                        $quote = 1;
                     } elsif ($field->[FIELD_TYPE] =~ m{blob|text|binary}sio) {
                         $value_type = DATA_BLOB;
                         $quote = 1;

--- a/lib/GenTest/Generator/FromGrammar.pm
+++ b/lib/GenTest/Generator/FromGrammar.pm
@@ -191,10 +191,6 @@ sub next {
 						$item = $prng->digit();
 					} elsif ($item eq '_positive_digit') {
 						$item = $prng->positive_digit();
-					} elsif ($item eq '_table') {
-						my $tables = $executors->[0]->metaTables($last_database);
-						$last_table = $prng->arrayElement($tables);
-						$item = '`'.$last_table.'`';
 					} elsif ($item eq '_hex') {
 						$item = $prng->hex();
 					} elsif ($item eq '_cwd') {


### PR DESCRIPTION
- Enable sqltrace (prints all the SQL statements with the --sqltrace option)

- Don't load 'text' type values like 'blob' on Postgres

- Run COUNT(*) queries to get table rows for unanalyzed tables