### PR TITLE
Fix empty rule choice array handling and yb-simplify-crash.pl

### DIFF
--- a/lib/GenTest/Generator/FromGrammar.pm
+++ b/lib/GenTest/Generator/FromGrammar.pm
@@ -156,10 +156,13 @@ sub next {
 					@{$rule_invariants->{$item}} = expand($rule_counters,$rule_invariants,($item)) unless defined $rule_invariants->{$item};
 					@expansion = @{$rule_invariants->{$item}};
 				} else {
-					@expansion = expand($rule_counters,$rule_invariants,@{$grammar_rules->{$item}->[GenTest::Grammar::Rule::RULE_COMPONENTS]->[
-						$prng->uint16(0, $#{$grammar_rules->{$item}->[GenTest::Grammar::Rule::RULE_COMPONENTS]})
-					]});
-
+                                        my $rule_choices = $grammar_rules->{$item}->[GenTest::Grammar::Rule::RULE_COMPONENTS];
+                                        # No space or newline between the colon and semicolon leads to an empty array.
+                                        # i.e.: "<rule>:;"  instead of "<rule>: ;"
+                                        if ($#{$rule_choices} >= 0) {
+                                                @expansion = expand($rule_counters,$rule_invariants,
+                                                                    @{$rule_choices->[$prng->uint16(0, $#{$rule_choices})]});
+                                        }
 				}
 				if ($generator->[GENERATOR_ANNOTATE_RULES]) {
 					@expansion = ("/* rule: $item */ ", @expansion);

--- a/util/yb-simplify-crash.pl
+++ b/util/yb-simplify-crash.pl
@@ -96,7 +96,7 @@ sub start_server {
 
 	if ((not defined $executor) || (not defined $executor->dbh()) || (!$executor->dbh()->ping())) {
             system($ybctl_cmd);
-            $executor = GenTest::Executor::MySQL->new( dsn => $dsn );
+            $executor = GenTest::Executor::Postgres->new( dsn => $dsn );
             $executor->init();
 	}
 }


### PR DESCRIPTION
- Fix obscure "Illegal modulus zero at lib/GenTest/Random.pm line 298." error from an empty rule that even lacks any whitespace in its body. e.g.: "rule:;" instead of "rule: ;" was causing the problem.

- Fix incorrect Executor type for stop & restart in yb-simplify-crash.pl.