### PR TITLE
Update name and version for Yugabyte

### DIFF
--- a/lib/GenTest/Executor/Postgres.pm
+++ b/lib/GenTest/Executor/Postgres.pm
@@ -235,8 +235,23 @@ sub findStatus {
     }
 }
 
+## Override the base name for ourselves with YB-specific behaviour
+sub getName {
+    my $self = shift;
+    my $yb = $self->yb_version();
+    if (defined $self->yb_version()) {
+        return "Yugabyte"
+    }
+
+    return "Postgres";
+}
+
 sub version {
     my $self = shift;
+    my $yb = $self->yb_version();
+    if (defined $yb) {
+        return $yb
+    }
     my $dbh = $self->dbh();
     return $dbh->get_info(18);
 }


### PR DESCRIPTION
Prior to this change, Yugabyte and Postgres log lines were difficult to distinguish because Yugabyte reused Postgres files in randgen. This PR changes the version output in the `gentest.pl` output:

Observe these snippets from the logs:
```
# 2024-02-20T12:14:01 [14034]  failed: Yugabyte 2.21.1.0-b0:42703:ERROR:  column subquery1_t3.col_varchar_key does not exist
# 2024-02-20T12:14:01 [14034]  failed: Postgres 11.00.2200:42703:ERROR:  column subquery1_t3.col_varchar_key does not exist
```

It is now much easier to tell which is Yugabyte. 