### PR TITLE
Unwrap IF EXISTS from the comment

### DIFF
--- a/lib/GenTest/App/Gendata.pm
+++ b/lib/GenTest/App/Gendata.pm
@@ -185,6 +185,8 @@ sub run {
     my $executor = GenTest::Executor->newFromDSN($self->dsn());
     $executor->init();
 
+    # Suppress NOTICE messages from CREATE ... IF EXISTS
+    $executor->dbh()->{PrintWarn} = 0 if $executor->type == DB_POSTGRES && !rqg_debug();
 #  
 # The specification file is actually a perl script, so we read it by
 # eval()-ing it

--- a/lib/GenTest/App/GendataSimple.pm
+++ b/lib/GenTest/App/GendataSimple.pm
@@ -110,6 +110,9 @@ sub run {
     $executor->sqltrace($self->sqltrace);
     $executor->setId($self->executor_id);
     $executor->init();
+
+    # Suppress NOTICE messages from CREATE ... IF EXISTS
+    $executor->dbh()->{PrintWarn} = 0 if $executor->type == DB_POSTGRES && !rqg_debug();
     
     my $names = GDS_DEFAULT_NAMES;
     my $rows;
@@ -222,8 +225,8 @@ sub gen_table {
         say("Creating ".$executor->getName()." table $name, size $size rows");
     
         my $increment_size = (length($name) > 1 ? (length($name) * 5) : 1);
-		$executor->execute("DROP TABLE /*! IF EXISTS */ $name");
-        $executor->execute("DROP SEQUENCE ".$name."_seq");
+		$executor->execute("DROP TABLE IF EXISTS $name");
+        $executor->execute("DROP SEQUENCE IF EXISTS ".$name."_seq");
         $executor->execute("CREATE SEQUENCE ".$name."_seq INCREMENT 1 START $increment_size");
 		$executor->execute("
 		CREATE TABLE $name (

--- a/lib/GenTest/Executor/Postgres.pm
+++ b/lib/GenTest/Executor/Postgres.pm
@@ -60,6 +60,8 @@ sub init {
 my %caches;
 
 my %acceptedErrors = (
+    ### TODO: 42P01 is also used for the missing/invalid FROM-clause entry errors, etc.
+    ### Fix the grammar rules leading to them then stop masking these errors.
     "42P01" => 1,# DROP TABLE on non-existing table is accepted since
                  # tests rely on non-standard MySQL DROP IF EXISTS;
     "42P06" => 1 # Schema already exists
@@ -80,6 +82,8 @@ sub execute {
     my $executor_id = $self->id();
     $query =~ s{/\*executor$executor_id (.*?) \*/}{$1}sg;
     $query =~ s{/\*executor.*?\*/}{}sgo;
+
+    $query =~ s{/\*!\s*IF\s+(|NOT\s+)EXISTS\s*\*/}{IF $1EXISTS}sgo;
     
     $query = $self->preprocess($query);
     


### PR DESCRIPTION
Data generators were wrapping IF (NOT) EXISTS option in the DDL commands in a comment block.

    e.g.: DROP TABLE /*! IF EXISTS  */ CA;

  - Unwrap it in Executor::Postgres

  - Also suppress warning messages ("NOTICE: ... does not exist, skipping...") in the data generators unless --debug command line option (or RQG_DEBUG env var) is specified.