### PR TITLE
Fix "missing/invalid table in FROM-clause" errors

### DIFF
--- a/conf/yugabyte/optimizer_no_subquery_portable.yy
+++ b/conf/yugabyte/optimizer_no_subquery_portable.yy
@@ -54,6 +54,10 @@
 query:
 	{ @nonaggregates = () ; $tables = 0 ; $fields = 0 ; "" } hints query_type ;
 
+################################################################################
+# YB: Randomly add a hint set that encourages Batched Nested Loop plans
+################################################################################
+
 hints: nl_hints | | ;
 
 nl_hints: /*+ Set(enable_hashjoin off) Set(enable_mergejoin off) Set(enable_material off) */ ;
@@ -177,6 +181,8 @@ not:
 # The IS not NULL values in where_item are to hit the ref_or_null and          #
 # the not_exists optimizations.  The LIKE '%a%' rule is to try to hit the      #
 # rnd_pos optimization                                                         #
+#                                                                              #
+# YB: Use _field_indexed instead of pk in the "IS not NULL" pattern            #
 ################################################################################
 where_item:
         table1 .`pk` arithmetic_operator existing_table_item . int_field_name  |
@@ -185,7 +191,7 @@ where_item:
         existing_table_item . char_field_name arithmetic_operator existing_table_item . char_field_name |
         existing_table_item . int_field_name arithmetic_operator int_value  |
         existing_table_item . char_field_name arithmetic_operator char_value  |
-        table1 .`pk` IS not NULL |
+        table1 . _field_indexed IS not NULL |
         table1 . _field IS not NULL |
         table1 . int_indexed arithmetic_operator int_value AND ( table1 . char_field_name LIKE '%a%' OR table1.char_field_name LIKE '%b%') ;
 

--- a/lib/GenTest/Executor/Postgres.pm
+++ b/lib/GenTest/Executor/Postgres.pm
@@ -60,11 +60,12 @@ sub init {
 my %caches;
 
 my %acceptedErrors = (
-    ### TODO: 42P01 is also used for the missing/invalid FROM-clause entry errors, etc.
-    ### Fix the grammar rules leading to them then stop masking these errors.
+    ## YB: 42P01 is also used for the missing/invalid FROM-clause entry errors, etc.
+    ## We now take the "IF (NOT) EXISTS" option out of the comment block and stop
+    ## masking these errors.
     "42P01" => 1,# DROP TABLE on non-existing table is accepted since
                  # tests rely on non-standard MySQL DROP IF EXISTS;
-    "42P06" => 1 # Schema already exists
+    # "42P06" => 1 # Schema already exists
     );
 
 sub execute {

--- a/lib/GenTest/Translator/MysqlDML2ANSI.pm
+++ b/lib/GenTest/Translator/MysqlDML2ANSI.pm
@@ -153,8 +153,8 @@ sub translate {
     $dml =~ s/\bSQL_SMALL_RESULT\b//gsi;
 
     ## SELECT STRAIGHT_JOIN is just translated to SELECT
-    $dml =~ s/\bSELECT(\s+DISTINCT|)\s+STRAIGHT_JOIN\b/SELECT/gsi;
-
+    $dml =~ s/\bSELECT\s+(\/\* rule: \w+ \*\/\s*)*STRAIGHT_JOIN\b/SELECT$1/gsi;
+    $dml =~ s/\bDISTINCT\s+(\/\* rule: \w+ \*\/\s*)*STRAIGHT_JOIN\b/DISTINCT$1/gsi;
     $dml =~ s/CONCAT\s*\(([^,]+),([^)]+)\)/\(\1 || \2 \)/gsi;
     
     ## Translate LIMIT semantics into ANSI


### PR DESCRIPTION
- The Postgres Executor was masking the error codes 42P01 and 42P06 in order to suppress the table/schema existence error on DROP/CREATE. We don't need to mask those errors for this purpose because Postgres does support IF EXISTS/IF NOT EXISTS.

  42P01 is also used for reporting missing table in the FROM-clause and out-of-scope table references, and some grammar rules sometimes produces invalid queries hitting those.

  For now, stop masking 42P06 but leave the 42P01 masked.

- Improve the STRAIGHT_JOIN (MySQL dialect) keyword stripping so it works with annotated rule names.

outer_join_portable.yy:

- Fix "missing table" errors originated from a SELECT-list item by joining additional tables.

optimizer_no_subquery_portable.yy:

- Change a where_item rule pattern: "pk IS not NULL" to "_field_indexed IS not NULL" to generate more sensible queries.

optimizer_subquery_portable.yy:

- Add character type "single member" subqueries.

- Fix type mismatch and enable originally commented-out "double member" subqueries.

- Fix "invalid table in FROM-clause" errors involving JOIN clauses in busy structure.

- Add scalar subquery variants that don't have an aggregate function.

- Add subqueries with predicates correlated to non-immediate outer query block.

yb-simplify-crash.pl:

- Add optional query hints to specify in each simplification step, in which all the comments are removed.

- Add yb-simplify-sporadic-crash.pl for simplifying query causing intermittent crash.