### PR TITLE
Filter improvement and Postgres reconnect support

### DIFF
--- a/conf/yugabyte/known_issues.ff
+++ b/conf/yugabyte/known_issues.ff
@@ -1,0 +1,9 @@
+$rules = {
+        # until #21012 gets fixed
+	'bug21012' => qr{\bHashAggregate\b.+[\n \[\],']+\bGroup Key:.+[\n \[\],']+\bInitPlan\b.+[\n \[\],']+->\s+Limit}o,
+
+	# 'no_bitmapscans' => qr{Bitmap}o,
+	# 'require_bitmapscans' => sub { $_ !~ m{Bitmap}sgo },
+	# 'no_bnl' => qr{YB Batched Nested Loop}o,
+	# 'require_bnl' => sub { $_ !~ m{YB Batched Nested Loop}sgo },
+};

--- a/conf/yugabyte/optimizer_subquery.ff
+++ b/conf/yugabyte/optimizer_subquery.ff
@@ -1,4 +1,0 @@
-$rules = {
-        # until #21012 gets fixed
-	'bug21012' => qr{\bHashAggregate\b.+[\n \[\],']+\bGroup Key:.+[\n \[\],']+\bInitPlan\b.+[\n \[\],']+->\s+Limit}o,
-};

--- a/lib/GenTest/Executor/Postgres.pm
+++ b/lib/GenTest/Executor/Postgres.pm
@@ -120,6 +120,15 @@ sub execute {
         }
     }
 
+    if (!$dbh->ping()) {
+        ## Reinit if connection is dead
+        say("Postgres connection is dead. Reconnect");
+        $self->disconnect();
+        sleep(1);
+        $self->init();
+        $dbh=$self->dbh();
+    }
+
     # Autocommit ?
 
     my $db = $self->getName()." ".$self->version();

--- a/lib/GenTest/Mixer.pm
+++ b/lib/GenTest/Mixer.pm
@@ -150,7 +150,9 @@ sub next {
 
 		if (defined $filters) {
 			foreach my $filter (@$filters) {
-				my $explain = Dumper $executors->[0]->execute("EXPLAIN $query") if $query =~ m{^\s*SELECT}sio;
+                                my $opt = "";
+                                $opt = " (COSTS OFF)" if $executors->[0]->type == DB_POSTGRES;
+				my $explain = Dumper $executors->[0]->execute("EXPLAIN$opt $query") if $query =~ m{^\s*(|\/\*\+ *[^\n]+ *\*\/)\s*SELECT}sio;
 				my $filter_result = $filter->filter($query." ".$explain);
 				next query if $filter_result == STATUS_SKIP;
 			}


### PR DESCRIPTION
- Plan node based filtering was previously not working with hinted SELECT queries.

- Reconnect when the connection died in the previous query.

- Rename optimizer_subquery.ff to known_issues.ff and add examples of excluding/requiring a certain plan node such as "Bitmap ...", "YB Batched Nested Loop".

yb-simplify-sporadic-crash.pl:
- Wait until the server start actually accepting connections.