### PR TITLE
Random number generator decimal value support and outer join test enh…

### DIFF
--- a/conf/yugabyte/outer_join.zz
+++ b/conf/yugabyte/outer_join.zz
@@ -20,22 +20,17 @@ $tables = {
 
 	#rows => [0, 1, 2, 5, 6, 7, 8, 9, 10, 20, 21, 22, 23, 24, 25, 100], # the original
 	rows => [0, 1, 8, 128, 210, 220, 255],
-
-	# N/A to non-MySQL DBs
-        #engines => ['MyISAM', 'Innodb' ]
 };
 
 $fields = {
-        types => [ 'int', 'varchar(10)', 'varchar(1024)' ],
+        types => [ 'int', 'bigint', 'decimal(5,2)', 'varchar(10)', 'varchar(1024)' ],
         indexes => [undef, 'key' ],
         null => [undef ],
-
-	# Non-standard "CARACTER SET" syntax will be commented out for non-MySQL-fork DBs
-	# and harmless.  Just leave it for now.
-        charsets => ['utf8', 'latin1']
 };
 
 $data = {
-        numbers => [ 'digit', 'null', undef ],
-        strings => [ 'letter', 'english' , 'string(1024)']
+      # disable full range values (undef) until 21758 gets fixed
+      #  numbers => [ 'digit', 'digit', 'digit', 'tinyint', 'tinyint', 'decimal(4,2)', 'null', undef ],
+        numbers => [ 'digit', 'digit', 'digit', 'tinyint', 'tinyint', 'decimal(4,2)', 'null' ],
+        strings => [ 'letter', 'tinyint', 'string(4)', 'english' , 'string(1024)']
 };

--- a/conf/yugabyte/outer_join_portable.yy
+++ b/conf/yugabyte/outer_join_portable.yy
@@ -70,7 +70,7 @@
 
 query:
   { $min_tables = 0; @table_alias_set = (1, 1, 1, 1, 2, 2, 2, 3, 4, 5, 1, 1, 2) ; "" }
-  { @int_field_set = ("pk", "col_int", "col_int_key") ; "" } 
+  { @int_field_set = ("pk", "col_int", "col_int_key", "col_bigint", "col_bigint_key", "col_decimal_5_2", "col_decimal_5_2") ; "" } 
   { $gby = "";  @nonaggregates = () ;  @aggregates = (); $t1 = 1; @st1 = (); $tables = 0 ; $fields = 0 ;  "" }
   hints query_type ;
 
@@ -158,15 +158,15 @@ aggregate_select_item:
 	{ my $x = join("", expand($rule_counters,$rule_invariants, "new_aggregate")); push @aggregates, $x; $x } AS { "field".++$fields };
 
 new_aggregate:
-	aggregate table_alias . int_field_name ) |
-	aggregate table_alias . int_field_name ) |
-	aggregate table_alias . int_field_name ) |
+	aggregate table_alias . _field_int ) |
+	aggregate table_alias . _field_int ) |
+	aggregate table_alias . _field_int ) |
 	literal_aggregate ;
 
 new_aggregate_existing_table_item:
-	aggregate existing_table_item . int_field_name ) |
-	aggregate existing_table_item . int_field_name ) |
-	aggregate existing_table_item . int_field_name ) |
+	aggregate existing_table_item . _field_int ) |
+	aggregate existing_table_item . _field_int ) |
+	aggregate existing_table_item . _field_int ) |
 	literal_aggregate ;
 
 table_alias:
@@ -198,30 +198,30 @@ join_condition:
    char_condition and_or where_item ;
 
 int_condition: 
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . int_indexed = 
-   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . int_indexed
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_int_indexed = 
+   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_int_indexed
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } |
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . int_indexed =
-   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . int_field_name
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_int_indexed =
+   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_int
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } |
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . int_field_name =
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_int =
    { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/,
- $table_string); $table_array[1] } . int_indexed
+ $table_string); $table_array[1] } . _field_int_indexed
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } |
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . int_field_name =
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_int =
    { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/,
- $table_string); $table_array[1] } . int_field_name
+ $table_string); $table_array[1] } . _field_int
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } ;
 
 char_condition:
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . char_field_name =
-   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . char_field_name 
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_char =
+   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_char 
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } |
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . char_indexed  =
-   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . char_field_name 
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_char_indexed  =
+   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_char 
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } |
-   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . char_field_name =
-   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . char_indexed 
+   { my $left = $stack->get("left"); my %s=map{$_=>1} @$left; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_char =
+   { my $right = $stack->get("result"); my %s=map{$_=>1} @$right; my @r=(keys %s); my $table_string = $prng->arrayElement(\@r); my @table_array = split(/AS/, $table_string); $table_array[1] } . _field_char_indexed 
    { my $left = $stack->get("left");  my $right = $stack->get("result"); my @n = (); push(@n,@$right); push(@n,@$left); $stack->pop(\@n); return undef } ;
 
 where_list:
@@ -229,16 +229,28 @@ where_list:
         ( where_list and_or where_item ) ;
 
 where_item:
-        existing_table_item . `pk` comparison_operator _digit  |
-        existing_table_item . `pk` comparison_operator existing_table_item . int_field_name  |
-	existing_table_item . int_field_name comparison_operator _digit  |
-        existing_table_item . int_field_name comparison_operator existing_table_item . int_field_name |
-        existing_table_item . int_field_name IS not NULL |
-        existing_table_item . int_field_name not IN (number_list) |
-        existing_table_item . int_field_name  not BETWEEN _digit[invariant] AND ( _digit[invariant] + _digit );
+        existing_table_item . `pk` comparison_operator number  |
+        existing_table_item . `pk` comparison_operator existing_table_item . _field_int  |
+	existing_table_item . _field_int comparison_operator number  |
+        existing_table_item . _field_int comparison_operator existing_table_item . _field_int |
+        existing_table_item . _field_int IS not NULL |
+        existing_table_item . _field_int not IN (number_list) |
+        existing_table_item . _field_int  not BETWEEN number[invariant] AND ( number[invariant] + _digit ) |
+	existing_table_item . _field_char comparison_operator char_value  |
+        existing_table_item . _field_char comparison_operator existing_table_item . _field_char |
+        existing_table_item . _field_char IS not NULL |
+        existing_table_item . _field_char not IN (char_list) |
+        existing_table_item . _field_char  not BETWEEN char_value[invariant] AND CONCAT(char_value[invariant], char_value) |
+	existing_table_item . _field_char not LIKE CONCAT(char_value, '%') ;
 
 number_list:
-        _digit | number_list, _digit ;
+        _digit | _digit | number | number_list, number ;
+
+char_list:
+        _char | char_list, _char ;
+
+char_value:
+	_char | _char(2) | _char(3) ;
 
 ################################################################################
 # YB: add missing tables referenced in the SELECT-list.                        #
@@ -286,7 +298,7 @@ having_list:
 
 having_item:
 	{ ($gby and @nonaggregates > 0 and (!@aggregates or $prng->int(1,3) == 1)) ? $prng->arrayElement(\@nonaggregates) : join("", expand($rule_counters,$rule_invariants, "new_aggregate_existing_table_item")) }
-	comparison_operator _digit ;
+	comparison_operator number ;
 
 ################################################################################
 # We use the total_order_by rule when using the LIMIT operator to ensure that  #
@@ -347,26 +359,6 @@ new_table_item:
 # We use the "AS table" bit here so we can have unique aliases if we use the same table many times
        { $stack->push(); my $x = $prng->arrayElement($executors->[0]->tables())." AS table".++$tables;  my @s=($x); $stack->pop(\@s); $x } ;
 
-int_field_name:
-  `pk` | `col_int_key` | `col_int` ;
-
-int_indexed:
-   `pk` | `col_int_key` ;
-
-char_field_name:
-  `col_varchar_10_utf8` | 
-  `col_varchar_10_latin1`| 
-  `col_varchar_1024_utf8_key` | 
-  `col_varchar_1024_utf8` | 
-  `col_varchar_1024_latin1_key` | 
-  `col_varchar_10_utf8_key` | 
-  `col_varchar_1024_latin1` | 
-  `col_varchar_10_latin1_key` ; 
-
-char_indexed:
-  `col_varchar_10_latin1_key` | `col_varchar_10_utf8_key` |
-  `col_varchar_1024_latin1_key` |`col_varchar_1024_utf8_key` ;
-
 agg_field_table_alias:
 	{ my $n = $prng->arrayElement(\@table_alias_set); $min_tables = $n if $min_tables < $n; "table".$n };
 
@@ -379,12 +371,23 @@ existing_select_item:
 _digit:
     1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
     1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | _tinyint_unsigned ;
+
+number:
+    _digit | _digit | _digit | _digit | _digit |
+    _digit | _digit | _digit | _digit | _digit |
+    _digit | _digit | _digit | _digit | _digit |
+    _digit | _digit | _digit | _digit | _digit ;
+
+number_disabled_bug21758:
+    4294967296 | -4294967296 | _bigint ;
  
 and_or:
    AND | AND | { $need_eq ? "AND" : "OR" } ;
 
 comparison_operator:
-	= | > | < | != | <> | <= | >= ;
+	= | > | < | <= | >= |
+	= | > | < | <= | >= |
+	!= | <> ;
 
 aggregate:
 	COUNT( distinct | SUM( distinct | MIN( distinct | MAX( distinct ;

--- a/lib/GenTest/Executor/Postgres.pm
+++ b/lib/GenTest/Executor/Postgres.pm
@@ -63,7 +63,7 @@ my %acceptedErrors = (
     ## YB: 42P01 is also used for the missing/invalid FROM-clause entry errors, etc.
     ## We now take the "IF (NOT) EXISTS" option out of the comment block and stop
     ## masking these errors.
-    "42P01" => 1,# DROP TABLE on non-existing table is accepted since
+    # "42P01" => 1,# DROP TABLE on non-existing table is accepted since
                  # tests rely on non-standard MySQL DROP IF EXISTS;
     # "42P06" => 1 # Schema already exists
     );
@@ -356,16 +356,15 @@ sub getSchemaMetaData {
     my $res = $self->dbh()->selectall_arrayref($query);
     croak("FATAL ERROR: Failed to retrieve schema metadata") unless $res;
 
-    my %table_rows = ();
-    foreach my $i (0..$#$res) {
-        my $tbl = $res->[$i]->[0].'.'.$res->[$i]->[1];
-        if (($res->[$i]->[2] == 'table') and
-            ((not defined $table_rows{$tbl}) or ($table_rows{$tbl} eq 'NULL') or ($table_rows{$tbl} eq ''))) {
-            my $count_row = $self->dbh()->selectrow_arrayref("SELECT COUNT(*) FROM $tbl");
-            $table_rows{$tbl} = $count_row->[0];
-        }
-        $res=>[$i]->[8] = $table_rows{$tbl};
-    }
+    # my %table_rows = ();
+    # foreach my $i (0..$#$res) {
+    #     my $tbl = $res->[$i]->[0].'.'.$res->[$i]->[1];
+    #     if ((not defined $table_rows{$tbl}) or ($table_rows{$tbl} eq 'NULL') or ($table_rows{$tbl} eq '')) {
+    #         my $count_row = $self->dbh()->selectrow_arrayref("SELECT COUNT(*) FROM $tbl");
+    #         $table_rows{$tbl} = $count_row->[0];
+    #     }
+    #     $res=>[$i]->[8] = $table_rows{$tbl};
+    # }
     return $res;
 }
 

--- a/lib/GenTest/Random.pm
+++ b/lib/GenTest/Random.pm
@@ -117,6 +117,8 @@ use constant FIELD_TYPE_JSONOBJECT  => 28;
 
 use constant FIELD_TYPE_TEXT  => 29;
 
+use constant FIELD_TYPE_NUMERIC_DECIMAL => 30;
+
 use constant ASCII_RANGE_START		=> 97;
 use constant ASCII_RANGE_END		=> 122;
 
@@ -159,6 +161,61 @@ my %name2type = (
 	'dec'			=> FIELD_TYPE_NUMERIC,
 	'numeric'		=> FIELD_TYPE_NUMERIC,
 	'fixed'			=> FIELD_TYPE_NUMERIC,
+	'char'			=> FIELD_TYPE_STRING,
+	'varchar'		=> FIELD_TYPE_STRING,
+	'binary'		=> FIELD_TYPE_BLOB,
+	'varbinary'		=> FIELD_TYPE_BLOB,
+	'tinyblob'		=> FIELD_TYPE_BLOB,
+	'blob'			=> FIELD_TYPE_BLOB,
+	'mediumblob'		=> FIELD_TYPE_BLOB,
+	'longblob'		=> FIELD_TYPE_BLOB,
+	'tinytext'		=> FIELD_TYPE_TEXT,
+	'text'			=> FIELD_TYPE_TEXT,
+	'mediumtext'		=> FIELD_TYPE_TEXT,
+	'longtext'		=> FIELD_TYPE_TEXT,
+	'date'			=> FIELD_TYPE_DATE,
+	'time'			=> FIELD_TYPE_TIME,
+	'datetime'		=> FIELD_TYPE_DATETIME,
+	'timestamp'		=> FIELD_TYPE_TIMESTAMP,
+	'year'			=> FIELD_TYPE_YEAR,
+	'enum'			=> FIELD_TYPE_ENUM,
+	'set'			=> FIELD_TYPE_SET,
+	'null'			=> FIELD_TYPE_NULL,
+	'letter'		=> FIELD_TYPE_LETTER,
+	'digit'			=> FIELD_TYPE_DIGIT,
+	'data'			=> FIELD_TYPE_BLOB,
+	'ascii'			=> FIELD_TYPE_ASCII,
+	'string'		=> FIELD_TYPE_STRING,
+	'empty'			=> FIELD_TYPE_EMPTY,
+
+	'hex'			=> FIELD_TYPE_HEX,
+	'quid'			=> FIELD_TYPE_QUID,
+	'json'			=> FIELD_TYPE_JSON,
+	'jsonpath'		=> FIELD_TYPE_JSONPATH,
+	'jsonkey'       => FIELD_TYPE_JSONKEY,
+	'jsonvalue'     => FIELD_TYPE_JSONVALUE,
+	'jsonarray'     => FIELD_TYPE_JSONARRAY,
+	'jsonpair'      => FIELD_TYPE_JSONPAIR,
+	'jsonobject'    => FIELD_TYPE_JSONOBJECT
+);
+
+my %name2subtype = (
+	'bit'			=> FIELD_TYPE_BIT,
+	'bool'			=> FIELD_TYPE_NUMERIC,
+	'boolean'		=> FIELD_TYPE_NUMERIC,
+	'tinyint'		=> FIELD_TYPE_NUMERIC,
+	'smallint'		=> FIELD_TYPE_NUMERIC,
+	'mediumint'		=> FIELD_TYPE_NUMERIC,
+	'int'			=> FIELD_TYPE_NUMERIC,
+	'integer'		=> FIELD_TYPE_NUMERIC,
+	'bigint'		=> FIELD_TYPE_NUMERIC,
+	'float'			=> FIELD_TYPE_FLOAT,
+	'double'		=> FIELD_TYPE_FLOAT,
+	'double precision'	=> FIELD_TYPE_FLOAT,
+	'decimal'		=> FIELD_TYPE_NUMERIC_DECIMAL,
+	'dec'			=> FIELD_TYPE_NUMERIC_DECIMAL,
+	'numeric'		=> FIELD_TYPE_NUMERIC_DECIMAL,
+	'fixed'			=> FIELD_TYPE_NUMERIC_DECIMAL,
 	'char'			=> FIELD_TYPE_STRING,
 	'varchar'		=> FIELD_TYPE_STRING,
 	'binary'		=> FIELD_TYPE_BLOB,
@@ -633,6 +690,11 @@ sub fieldType {
 	} elsif ($field_type == FIELD_TYPE_LETTER) {
 		return $rand->string(1);
 	} elsif ($field_type == FIELD_TYPE_NUMERIC) {
+                if ($name2subtype{$field_full_type} == FIELD_TYPE_NUMERIC_DECIMAL) {
+                    my ($prec, $scale) = split(/,/, $field_length);
+                    my $bound = ('9' x ($prec - $scale)).".".('9' x $scale);
+                    return sprintf("%.".$scale."f", $rand->float("-".$bound, $bound));
+                }
 		return $rand->int(@{$name2range{$field_full_type}});
 	} elsif ($field_type == FIELD_TYPE_FLOAT) {
 		return $rand->float(@{$name2range{$field_full_type}});


### PR DESCRIPTION
…ancements

- Random generator can now generate decimal values with specified precision and scale.

yugabyte/{outer_join.zz, outer_join_portable.yy}:

- Add decimal type columns.

- Reduce the null value probabilities and add more column value variations.

Postgres executor:

- Stop masking the error 42P01 (missing table, invalid table references, etc.) that was originally for suppressing the errors from DROP TABLE statements.

- Disable row count queries for the tables without the stats.