### PR TITLE
Gendata and simplifier fixes and enhancements

### DIFF
--- a/lib/GenTest/App/GendataSimple.pm
+++ b/lib/GenTest/App/GendataSimple.pm
@@ -248,11 +248,11 @@ sub gen_table {
 
 			PRIMARY KEY (pk))");
 
-		$executor->execute("CREATE INDEX ".$name."_int_key ON $name(col_int_key)");
+		$executor->execute("CREATE INDEX ".$name."_int_key ON $name(col_int_key, col_varchar_key)");
 		$executor->execute("CREATE INDEX ".$name."_date_key ON $name(col_date_key)");
 		$executor->execute("CREATE INDEX ".$name."_time_key ON $name(col_time_key)");
 		$executor->execute("CREATE INDEX ".$name."_datetime_key ON $name(col_datetime_key)");
-		$executor->execute("CREATE INDEX ".$name."_varchar_key ON $name(col_varchar_key, col_int_key)");
+		$executor->execute("CREATE INDEX ".$name."_varchar_key ON $name(col_varchar_key, col_int_key, col_datetime_key)");
 
 	} else {
         say("Creating ".$executor->getName()." table $name, size $size rows");

--- a/lib/GenTest/Random.pm
+++ b/lib/GenTest/Random.pm
@@ -692,8 +692,15 @@ sub fieldType {
 	} elsif ($field_type == FIELD_TYPE_NUMERIC) {
                 if ($name2subtype{$field_full_type} == FIELD_TYPE_NUMERIC_DECIMAL) {
                     my ($prec, $scale) = split(/,/, $field_length);
-                    my $bound = ('9' x ($prec - $scale)).".".('9' x $scale);
-                    return sprintf("%.".$scale."f", $rand->float("-".$bound, $bound));
+                    my $value = $rand->int(0, ('9' x $prec) + 0);
+                    if ($scale > 0) {
+                        $value /= ('9' x $scale) + 1;
+                    } elsif ($scale < 0) {
+                        my $divisor = ('9' x -$scale) + 1;
+                        $value = sprintf("%.0f", $value / $divisor) * $divisor;
+                    }
+                    $value *= -1 if $rand->int(0, 1) == 1;
+                    return $value;
                 }
 		return $rand->int(@{$name2range{$field_full_type}});
 	} elsif ($field_type == FIELD_TYPE_FLOAT) {

--- a/lib/GenTest/Translator/MysqlDML2ANSI.pm
+++ b/lib/GenTest/Translator/MysqlDML2ANSI.pm
@@ -155,6 +155,7 @@ sub translate {
     ## SELECT STRAIGHT_JOIN is just translated to SELECT
     $dml =~ s/\bSELECT\s+(\/\* rule: \w+ \*\/\s*)*STRAIGHT_JOIN\b/SELECT$1/gsi;
     $dml =~ s/\bDISTINCT\s+(\/\* rule: \w+ \*\/\s*)*STRAIGHT_JOIN\b/DISTINCT$1/gsi;
+    $dml =~ s/CONCAT\s*\(([^,]+),([^)]+),([^)]+)\)/\(\1 || \2 || \3 \)/gsi;
     $dml =~ s/CONCAT\s*\(([^,]+),([^)]+)\)/\(\1 || \2 \)/gsi;
     
     ## Translate LIMIT semantics into ANSI


### PR DESCRIPTION
- Fix random decimal value generator that was occasionally generating out-of-the-range values because of machine float imprecision.

- ANSI translator CONCAT function 3rd argument support.

- Create a few more composite indexes in the default simple data generator.

- Fix table simplifier:
  - Don't drop the columns not ending in _key or _nokey suffix.

  - Don't drop the columns not explicitly used in the query but parts of composite indexes that may be required for the test case.

  - Dump the DUMMY table if it is used in the test query.