### PR TITLE
Gendata and simplifier fixes and enhancements

### DIFF
--- a/lib/GenTest/App/GendataSimple.pm
+++ b/lib/GenTest/App/GendataSimple.pm
@@ -248,11 +248,11 @@ sub gen_table {
 
 			PRIMARY KEY (pk))");
 
-		$executor->execute("CREATE INDEX ".$name."_int_key ON $name(col_int_key)");
+		$executor->execute("CREATE INDEX ".$name."_int_key ON $name(col_int_key, col_varchar_key)");
 		$executor->execute("CREATE INDEX ".$name."_date_key ON $name(col_date_key)");
 		$executor->execute("CREATE INDEX ".$name."_time_key ON $name(col_time_key)");
 		$executor->execute("CREATE INDEX ".$name."_datetime_key ON $name(col_datetime_key)");
-		$executor->execute("CREATE INDEX ".$name."_varchar_key ON $name(col_varchar_key, col_int_key)");
+		$executor->execute("CREATE INDEX ".$name."_varchar_key ON $name(col_varchar_key, col_int_key, col_datetime_key)");
 
 	} else {
         say("Creating ".$executor->getName()." table $name, size $size rows");

--- a/lib/GenTest/Random.pm
+++ b/lib/GenTest/Random.pm
@@ -692,8 +692,15 @@ sub fieldType {
 	} elsif ($field_type == FIELD_TYPE_NUMERIC) {
                 if ($name2subtype{$field_full_type} == FIELD_TYPE_NUMERIC_DECIMAL) {
                     my ($prec, $scale) = split(/,/, $field_length);
-                    my $bound = ('9' x ($prec - $scale)).".".('9' x $scale);
-                    return sprintf("%.".$scale."f", $rand->float("-".$bound, $bound));
+                    my $value = $rand->int(0, ('9' x $prec) + 0);
+                    if ($scale > 0) {
+                        $value /= ('9' x $scale) + 1;
+                    } elsif ($scale < 0) {
+                        my $divisor = ('9' x -$scale) + 1;
+                        $value = sprintf("%.0f", $value / $divisor) * $divisor;
+                    }
+                    $value *= -1 if $rand->int(0, 1) == 1;
+                    return $value;
                 }
 		return $rand->int(@{$name2range{$field_full_type}});
 	} elsif ($field_type == FIELD_TYPE_FLOAT) {

--- a/lib/GenTest/Translator/MysqlDML2ANSI.pm
+++ b/lib/GenTest/Translator/MysqlDML2ANSI.pm
@@ -155,6 +155,7 @@ sub translate {
     ## SELECT STRAIGHT_JOIN is just translated to SELECT
     $dml =~ s/\bSELECT\s+(\/\* rule: \w+ \*\/\s*)*STRAIGHT_JOIN\b/SELECT$1/gsi;
     $dml =~ s/\bDISTINCT\s+(\/\* rule: \w+ \*\/\s*)*STRAIGHT_JOIN\b/DISTINCT$1/gsi;
+    $dml =~ s/CONCAT\s*\(([^,]+),([^)]+),([^)]+)\)/\(\1 || \2 || \3 \)/gsi;
     $dml =~ s/CONCAT\s*\(([^,]+),([^)]+)\)/\(\1 || \2 \)/gsi;
     
     ## Translate LIMIT semantics into ANSI

--- a/util/yb-simplify-crash.pl
+++ b/util/yb-simplify-crash.pl
@@ -82,10 +82,13 @@ my $simplifier = GenTest::Simplifier::SQL->new(
 );
 
 my $simplified_query = $simplifier->simplify($original_query);
-die "Failed to simplify the query\n" if !$simplified_query;
-$simplified_query = $prefix.$simplified_query;
 
-print "Simplified query:\n$simplified_query;\n\n";
+if (!$simplified_query or $simplified_query =~ /$prefix/) {
+    print "\nFailed to simplify the query\n";
+    exit;
+}
+print "\nSimplified query:\n$prefix$simplified_query;\n\n";
+
 
 my $simplifier_test = GenTest::Simplifier::Test->new(
 	executors => [ $executor ],
@@ -93,6 +96,7 @@ my $simplifier_test = GenTest::Simplifier::Test->new(
 );
 
 my $simplified_test = $simplifier_test->simplify();
+$simplified_test = $prefix.$simplified_test;
 
 print "Simplified test\n\n";
 print $simplified_test;

--- a/util/yb-simplify-query.pl
+++ b/util/yb-simplify-query.pl
@@ -146,10 +146,13 @@ my $simplifier = GenTest::Simplifier::SQL->new(
 );
 
 my $simplified_query = $simplifier->simplify($query);
-die "Failed to simplify the query\n" if !$simplified_query;
-$simplified_query = $prefix.$simplified_query;
 
-print "\nSimplified query:\n$simplified_query;\n\n";
+if (!$simplified_query or $simplified_query =~ /$prefix/) {
+    print "\nFailed to simplify the query\n";
+    exit;
+}
+print "\nSimplified query:\n$prefix$simplified_query;\n\n";
+
 
 my @simplified_results;
 

--- a/util/yb-simplify-sporadic-crash.pl
+++ b/util/yb-simplify-sporadic-crash.pl
@@ -105,7 +105,13 @@ my $simplifier = GenTest::Simplifier::SQL->new(
 );
 
 my $simplified_query = $simplifier->simplify($original_query);
-print "Simplified query:\n$prefix$simplified_query;\n\n";
+
+if (!$simplified_query or $simplified_query =~ /$prefix/) {
+    print "\nFailed to simplify the query\n";
+    exit;
+}
+print "\nSimplified query:\n$prefix$simplified_query;\n\n";
+
 
 my $simplifier_test = GenTest::Simplifier::Test->new(
 	executors => [ $executor ],
@@ -113,7 +119,6 @@ my $simplifier_test = GenTest::Simplifier::Test->new(
 );
 
 my $simplified_test = $simplifier_test->simplify();
-die "Failed to simplify the query\n" if !$simplified_test;
 $simplified_test = $prefix.$simplified_test;
 
 print "Simplified test\n\n";


### PR DESCRIPTION
- Fix random decimal value generator that was occasionally generating out-of-the-range values because of machine float imprecision.

- ANSI translator CONCAT function 3rd argument support.

- Create a few more composite indexes in the default simple data generator.

- Fix table simplifier:
  - Don't drop the columns not ending in _key or _nokey suffix.

  - Don't drop the columns not explicitly used in the query but parts of composite indexes that may be required for the test case.

  - Dump the DUMMY table if it is used in the test query.

- Fix failed simplification detection in yb-simplify-*.pl so it bails out without going dumping the test data.