### PR TITLE
Create composite key indexes via gendata spec

### DIFF
--- a/conf/yugabyte/outer_join.zz
+++ b/conf/yugabyte/outer_join.zz
@@ -28,6 +28,16 @@ $fields = {
         null => [undef ],
 };
 
+$indexes = {
+	 idx1 => ['int', 'bigint', 'varchar(10)'],
+	 idx2 => ['int', 'varchar(10)', 'varchar(1024)', 'bigint'],
+	 idx3 => ['decimal(5,2)', 'varchar(10)', 'bigint', 'int'],
+	 idx4 => ['bigint', 'varchar(10)', 'decimal(5,2)', 'varchar(1024)'],
+	 idx5 => ['varchar(1024)', 'int', 'varchar(10)'],
+	 idx6 => ['varchar(10)', 'bigint', 'varchar(1024)', 'int'],
+	 idx7 => ['varchar(1024)', 'varchar(10)', 'int'],
+};
+
 $data = {
         numbers => [ 'digit', 'digit', 'digit', 'tinyint', 'tinyint', 'decimal(4,2)', 'null', undef ],
         strings => [ 'letter', 'tinyint', 'string(4)', 'english' , 'string(1024)']


### PR DESCRIPTION
* Add "$indexes" section for specifying composite key indexes.

  - Indexed field of the specified data type is used as each key item at the corresponding position in each key list. One field is randomly picked if there are multiple variants with different nullability, etc.

  - The key list names (idx1, etc. in the example below) can be any arbitrary perl identifier string and unused as a part of the index names.

  - Works with explicitly specified field names and short names (--short_column_names option), too.

Example:

$tables = {
        names => ['A','AA','B'],
	rows => [0, 100, 255],
};

$fields = {
        types => [ 'int', 'bigint', 'decimal(5,2)', 'varchar(10)', 'varchar(1024)' ],
        indexes => [undef, 'key' ],
        null => [undef, 'not null' ],
};

$indexes = {
	 idx1 => ['bigint', 'varchar(10)', 'decimal(5,2)', 'varchar(1024)'],
	 idx2 => ['varchar(1024)', 'int', 'varchar(10)'],
};

The spec above would create the following indexes:

CREATE INDEX idx_A_int_bigint_varchar_10 ON A(col_int_key,col_bigint_key,col_varchar_10_not_null_key); CREATE INDEX idx_A_varchar_1024_varchar_10_int ON A(col_varchar_1024_key,col_varchar_10_key,col_int_key); CREATE INDEX idx_AA_int_bigint_varchar_10 ON AA(col_int_key,col_bigint_not_null_key,col_varchar_10_key); CREATE INDEX idx_AA_varchar_1024_varchar_10_int ON AA(col_varchar_1024_key,col_varchar_10_key,col_int_key); CREATE INDEX idx_B_int_bigint_varchar_10 ON B(col_int_key,col_bigint_not_null_key,col_varchar_10_key); CREATE INDEX idx_B_varchar_1024_varchar_10_int ON B(col_varchar_1024_key,col_varchar_10_key,col_int_not_null_key);