### PR TITLE
Add support to create tables with mixed colocation for yugabyte db

### DIFF
--- a/lib/GenTest/App/Gendata.pm
+++ b/lib/GenTest/App/Gendata.pm
@@ -187,7 +187,10 @@ sub run {
     my $executor = GenTest::Executor->newFromDSN($self->dsn());
     $executor->init();
 
-    my $is_database_colocated = $executor->isColocated();
+    my $is_database_colocated = undef;
+    if (defined $executor->can("isColocated")) {
+        $is_database_colocated = $executor->isColocated();
+    }
     say ("is database colocated: $is_database_colocated.");
 
     # Suppress NOTICE messages from CREATE ... IF EXISTS

--- a/lib/GenTest/App/Gendata.pm
+++ b/lib/GenTest/App/Gendata.pm
@@ -241,7 +241,7 @@ sub run {
     $table_perms[TABLE_MERGES] = $tables->{merges} || undef ;
     
     $table_perms[TABLE_NAMES] = $tables->{names} || [ ];
-    $table_perms[TABLE_COLOCATION] = $tables->{colocation} || [ ];
+    $table_perms[TABLE_COLOCATION] = $tables->{colocation} || [ undef ];
 
     $field_perms[FIELD_NAMES] = $fields->{names} || [ ];
     $field_perms[FIELD_SQLS] = $fields->{sqls} || [ ];
@@ -472,7 +472,7 @@ sub run {
         $table_copy[TABLE_COLLATION] = "COLLATE ".$table_copy[TABLE_COLLATION] if $table_copy[TABLE_COLLATION] ne '';
         $table_copy[TABLE_PARTITION] = "/*!50100 PARTITION BY ".$table_copy[TABLE_PARTITION]." */" if $table_copy[TABLE_PARTITION] ne '';
 
-        if (defined $table_copy[TABLE_COLOCATION] and $is_database_colocated) {
+        if ($table_copy[TABLE_COLOCATION] ne '' and $is_database_colocated) {
             $table_copy[TABLE_COLOCATION] = "WITH ( COLOCATION=".$table_copy[TABLE_COLOCATION]." )";
         } else {
             delete $table_copy[TABLE_COLOCATION]; # Do not include colocation expression.

--- a/lib/GenTest/Executor/Postgres.pm
+++ b/lib/GenTest/Executor/Postgres.pm
@@ -292,7 +292,16 @@ sub currentSchema {
     }
     
 	return $self->dbh()->selectrow_array("SELECT current_schema()");
-}
+    }
+
+sub isColocated {
+	my ($self) = @_;
+        my $exec_name = $self->getName();
+	return undef if not defined $self->dbh() or not defined $exec_name or $exec_name != "Yugabyte";
+
+        my $result = $self->dbh()->selectrow_array("select yb_is_database_colocated()");
+        return $result;
+    }
 
 sub getSchemaMetaData {
     ## Return the result from a query with the following columns:


### PR DESCRIPTION
If executor is a yb database, and database is a colocated database then tables are created with colocation true or false.

```
$tables = {
        names => ['A','AA','B','BB','C','CC','D','DD','E','EE','F','FF','G','GG','H','HH','I','II','J','JJ','K','KK','L','LL','M','MM','N','NN','O','OO','P','PP'],

	#rows => [0, 1, 2, 5, 6, 7, 8, 9, 10, 20, 21, 22, 23, 24, 25, 100], # the original
	rows => [1, 10, 80, 10, 128, 210, 220, 255],
        colocation => ['false', 'true']
};
```