### PR TITLE
Fix regexp for checking a select query in mixer and validators

### DIFF
--- a/lib/GenTest.pm
+++ b/lib/GenTest.pm
@@ -19,11 +19,11 @@
 package GenTest;
 use base 'Exporter';
 
-@EXPORT = ('say', 'sayError', 'sayFile', 'tmpdir', 'safe_exit', 
+@EXPORT = ('say', 'sayError', 'sayFile', 'tmpdir', 'safe_exit',
            'osWindows', 'osLinux', 'osSolaris', 'osMac',
-           'isoTimestamp', 'isoUTCTimestamp', 'isoUTCSimpleTimestamp', 
+           'isoTimestamp', 'isoUTCTimestamp', 'isoUTCSimpleTimestamp',
            'rqg_debug', 'unix2winPath',
-           'setLoggingToFile','setLogConf','shorten_message');
+           'setLoggingToFile','setLogConf','shorten_message', 'is_query_a_select');
 
 use strict;
 
@@ -344,3 +344,9 @@ sub shorten_message {
 }
 
 1;
+
+# Returns true is the query is a select
+sub is_query_a_select {
+    my $query = shift;
+    return ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+}

--- a/lib/GenTest/Mixer.pm
+++ b/lib/GenTest/Mixer.pm
@@ -149,7 +149,7 @@ sub next {
 		}
 
 		if (defined $filters) {
-                    my $is_select = ($query =~ s{/\*.+\*/}{}sgor) =~ m{^\s*SELECT}sio;
+                    my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
                     foreach my $ex (@$executors) {
 			foreach my $filter (@$filters) {
                                 my $opt = " (COSTS OFF)" if $ex->type == DB_POSTGRES;

--- a/lib/GenTest/Mixer.pm
+++ b/lib/GenTest/Mixer.pm
@@ -149,7 +149,7 @@ sub next {
 		}
 
 		if (defined $filters) {
-                    my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+                    my $is_select = is_query_a_select($query);
                     foreach my $ex (@$executors) {
 			foreach my $filter (@$filters) {
                                 my $opt = " (COSTS OFF)" if $ex->type == DB_POSTGRES;

--- a/lib/GenTest/Validator/ExecutionTimeComparator.pm
+++ b/lib/GenTest/Validator/ExecutionTimeComparator.pm
@@ -207,8 +207,8 @@ sub validate {
 
     my $query = $results->[0]->query();
     $candidate_queries++;
-
-    if ($query !~ m{^\s*SELECT}sio) {
+    my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+    if (not $is_select) {
         $non_selects++;
         return STATUS_WONT_HANDLE;
     }

--- a/lib/GenTest/Validator/ExecutionTimeComparator.pm
+++ b/lib/GenTest/Validator/ExecutionTimeComparator.pm
@@ -207,7 +207,7 @@ sub validate {
 
     my $query = $results->[0]->query();
     $candidate_queries++;
-    my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+    my $is_select = is_query_a_select($query);
     if (not $is_select) {
         $non_selects++;
         return STATUS_WONT_HANDLE;

--- a/lib/GenTest/Validator/ExplainMatch.pm
+++ b/lib/GenTest/Validator/ExplainMatch.pm
@@ -39,7 +39,8 @@ sub validate {
 	my $executor = $executors->[0];
 	my $query = $results->[0]->query();
 
-	return STATUS_WONT_HANDLE if $query !~ m{^\s*SELECT}sio;
+        my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+	return STATUS_WONT_HANDLE if not $is_select;
 
         my $explain_output = $executor->dbh()->selectall_arrayref("EXPLAIN $query");
 

--- a/lib/GenTest/Validator/ExplainMatch.pm
+++ b/lib/GenTest/Validator/ExplainMatch.pm
@@ -39,7 +39,7 @@ sub validate {
 	my $executor = $executors->[0];
 	my $query = $results->[0]->query();
 
-        my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($query);
 	return STATUS_WONT_HANDLE if not $is_select;
 
         my $explain_output = $executor->dbh()->selectall_arrayref("EXPLAIN $query");

--- a/lib/GenTest/Validator/Limit.pm
+++ b/lib/GenTest/Validator/Limit.pm
@@ -35,14 +35,15 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-	return STATUS_OK if $orig_query !~ m{^\s*select}io;
+        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+	return STATUS_OK if not $is_select;
 	return STATUS_OK if $orig_query =~ m{limit}io;
 
 	my $fields = $executor->metaColumns();
 	my @field_orders = map { 'ORDER BY `'.$_.'` LIMIT 1073741824' } @$fields;
 
 	my $new_query = $orig_query;
-	# Remove existing ORDER BY if present 
+	# Remove existing ORDER BY if present
 	$new_query =~ s{ORDER BY [^)]*?$}{}io;
 
 	foreach my $predicate ( @field_orders ) {

--- a/lib/GenTest/Validator/Limit.pm
+++ b/lib/GenTest/Validator/Limit.pm
@@ -35,7 +35,7 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($orig_query);
 	return STATUS_OK if not $is_select;
 	return STATUS_OK if $orig_query =~ m{limit}io;
 

--- a/lib/GenTest/Validator/OrderBy.pm
+++ b/lib/GenTest/Validator/OrderBy.pm
@@ -35,7 +35,8 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-	return STATUS_OK if $orig_query !~ m{^\s*select}io;
+        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+	return STATUS_OK if not $is_select;
 
 	my $fields = $executor->metaColumns();
 	my @field_orders = map { 'ORDER BY OUTR . `'.$_.'` , OUTR . `pk`' } @$fields;

--- a/lib/GenTest/Validator/OrderBy.pm
+++ b/lib/GenTest/Validator/OrderBy.pm
@@ -35,7 +35,7 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($orig_query);
 	return STATUS_OK if not $is_select;
 
 	my $fields = $executor->metaColumns();

--- a/lib/GenTest/Validator/Performance.pm
+++ b/lib/GenTest/Validator/Performance.pm
@@ -49,8 +49,9 @@ sub validate {
 	my ($comparator, $executors, $results) = @_;
 
 	die "Performance validator only works with two servers" if $#$results != 1;
-
-	if ($results->[0]->query() !~ m{^\s*SELECT}sio) {
+        my $query = $results->[0]->query();
+        my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+	if (not $is_select) {
 		$counters{'non-SELECT queries'}++;
 		return STATUS_WONT_HANDLE;
 	} elsif ($results->[0]->status() != $results->[1]->status()) {

--- a/lib/GenTest/Validator/Performance.pm
+++ b/lib/GenTest/Validator/Performance.pm
@@ -50,7 +50,7 @@ sub validate {
 
 	die "Performance validator only works with two servers" if $#$results != 1;
         my $query = $results->[0]->query();
-        my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($query);
 	if (not $is_select) {
 		$counters{'non-SELECT queries'}++;
 		return STATUS_WONT_HANDLE;

--- a/lib/GenTest/Validator/RepeatableRead.pm
+++ b/lib/GenTest/Validator/RepeatableRead.pm
@@ -46,7 +46,8 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-	return STATUS_OK if $orig_query !~ m{^\s*select}io;
+        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+	return STATUS_OK if not $is_select;
 	return STATUS_OK if $orig_result->err() > 0;
 
 	foreach my $predicate (@predicates) {

--- a/lib/GenTest/Validator/RepeatableRead.pm
+++ b/lib/GenTest/Validator/RepeatableRead.pm
@@ -46,7 +46,7 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($orig_query);
 	return STATUS_OK if not $is_select;
 	return STATUS_OK if $orig_result->err() > 0;
 

--- a/lib/GenTest/Validator/ResultsetComparator.pm
+++ b/lib/GenTest/Validator/ResultsetComparator.pm
@@ -49,12 +49,13 @@ sub validate {
 	}
 
 	if ($compare_outcome == STATUS_LENGTH_MISMATCH) {
-		if ($query =~ m{^\s*select}io) {
-	                say("Query: $query failed: result length mismatch between servers (".$results->[0]->rows()." vs. ".$results->[1]->rows().")");
-			say(GenTest::Comparator::dumpDiff($results->[0], $results->[1]));
-		} else {
-	                say("Query: $query failed: affected_rows mismatch between servers (".$results->[0]->affectedRows()." vs. ".$results->[1]->affectedRows().")");
-		}
+                my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+                if ($is_select) {
+                    say("Query: $query failed: result length mismatch between servers (".$results->[0]->rows()." vs. ".$results->[1]->rows().")");
+                    say(GenTest::Comparator::dumpDiff($results->[0], $results->[1]));
+                } else {
+                    say("Query: $query failed: affected_rows mismatch between servers (".$results->[0]->affectedRows()." vs. ".$results->[1]->affectedRows().")");
+                }
 	} elsif ($compare_outcome == STATUS_CONTENT_MISMATCH) {
 		say("Query: ".$results->[0]->query()." failed: result content mismatch between servers.");
 		say(GenTest::Comparator::dumpDiff($results->[0], $results->[1]));

--- a/lib/GenTest/Validator/ResultsetComparator3.pm
+++ b/lib/GenTest/Validator/ResultsetComparator3.pm
@@ -39,7 +39,8 @@ sub compareTwo {
     my $outcome = GenTest::Comparator::compare($res1, $res2);
 
     if ($outcome == STATUS_LENGTH_MISMATCH) {
-        if ($q =~ m{^\s*select}io) {
+        my $is_select = ($q =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        if ($is_select) {
             say("-----------");
             say("Result length mismatch between $s1 and $s2 (".$res1->rows()." vs. ".$res2->rows().")");
             say("Query1: " . $res1->query());

--- a/lib/GenTest/Validator/ResultsetComparator3.pm
+++ b/lib/GenTest/Validator/ResultsetComparator3.pm
@@ -39,7 +39,7 @@ sub compareTwo {
     my $outcome = GenTest::Comparator::compare($res1, $res2);
 
     if ($outcome == STATUS_LENGTH_MISMATCH) {
-        my $is_select = ($q =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($q);
         if ($is_select) {
             say("-----------");
             say("Result length mismatch between $s1 and $s2 (".$res1->rows()." vs. ".$res2->rows().")");

--- a/lib/GenTest/Validator/ResultsetComparator3Simplify.pm
+++ b/lib/GenTest/Validator/ResultsetComparator3Simplify.pm
@@ -42,7 +42,8 @@ sub compareTwo {
     my $outcome = GenTest::Comparator::compare($res1, $res2);
 
     if ($outcome == STATUS_LENGTH_MISMATCH) {
-        if ($q =~ m{^\s*select}io) {
+        my $is_select = ($q =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        if ($is_select) {
             say("-----------");
             say("Result length mismatch between $s1 and $s2 (".$res1->rows()." vs. ".$res2->rows().")");
             say("Query1: " . $res1->query());

--- a/lib/GenTest/Validator/ResultsetComparator3Simplify.pm
+++ b/lib/GenTest/Validator/ResultsetComparator3Simplify.pm
@@ -42,7 +42,7 @@ sub compareTwo {
     my $outcome = GenTest::Comparator::compare($res1, $res2);
 
     if ($outcome == STATUS_LENGTH_MISMATCH) {
-        my $is_select = ($q =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($q);
         if ($is_select) {
             say("-----------");
             say("Result length mismatch between $s1 and $s2 (".$res1->rows()." vs. ".$res2->rows().")");

--- a/lib/GenTest/Validator/ResultsetComparatorGIS.pm
+++ b/lib/GenTest/Validator/ResultsetComparatorGIS.pm
@@ -82,7 +82,8 @@ sub validate {
 	}
 
 	if ($compare_outcome == STATUS_LENGTH_MISMATCH) {
-		if ($query =~ m{^\s*select}io) {
+                my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+		if ($is_select) {
 	                say("Query: $query failed: result length mismatch between servers (".$results->[0]->rows()." vs. ".$results->[1]->rows().")");
 			say(GenTest::Comparator::dumpDiff($results->[0], $results->[1]));
 		} else {

--- a/lib/GenTest/Validator/ResultsetComparatorGIS.pm
+++ b/lib/GenTest/Validator/ResultsetComparatorGIS.pm
@@ -82,7 +82,7 @@ sub validate {
 	}
 
 	if ($compare_outcome == STATUS_LENGTH_MISMATCH) {
-                my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+                my $is_select = is_query_a_select($query);
 		if ($is_select) {
 	                say("Query: $query failed: result length mismatch between servers (".$results->[0]->rows()." vs. ".$results->[1]->rows().")");
 			say(GenTest::Comparator::dumpDiff($results->[0], $results->[1]));

--- a/lib/GenTest/Validator/ResultsetComparatorSimplify.pm
+++ b/lib/GenTest/Validator/ResultsetComparatorSimplify.pm
@@ -66,9 +66,10 @@ sub validate {
 	) {
 		say("---------- RESULT COMPARISON ISSUE START ----------");
 	}
-		
+
+	my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
 	if ($compare_outcome == STATUS_LENGTH_MISMATCH) {
-		if ($query =~ m{^\s*select}io) {
+		if ($is_select) {
 	                say("Query: $query; failed: result length mismatch between servers (".$results->[0]->rows()." vs. ".$results->[1]->rows().")");
 			say(GenTest::Comparator::dumpDiff($results->[0], $results->[1]));
 		} else {
@@ -80,7 +81,7 @@ sub validate {
 	}
 
 	if (
-		($query =~ m{^\s*select}sio) && (
+		($is_select) && (
 			($compare_outcome == STATUS_LENGTH_MISMATCH) ||
 			($compare_outcome == STATUS_CONTENT_MISMATCH)
 		)

--- a/lib/GenTest/Validator/ResultsetComparatorSimplify.pm
+++ b/lib/GenTest/Validator/ResultsetComparatorSimplify.pm
@@ -67,7 +67,7 @@ sub validate {
 		say("---------- RESULT COMPARISON ISSUE START ----------");
 	}
 
-	my $is_select = ($query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($query);
 	if ($compare_outcome == STATUS_LENGTH_MISMATCH) {
 		if ($is_select) {
 	                say("Query: $query; failed: result length mismatch between servers (".$results->[0]->rows()." vs. ".$results->[1]->rows().")");

--- a/lib/GenTest/Validator/SelectStability.pm
+++ b/lib/GenTest/Validator/SelectStability.pm
@@ -35,7 +35,8 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-	return STATUS_OK if $orig_query !~ m{^\s*select}io;
+        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+	return STATUS_OK if not $is_select;
 	return STATUS_OK if not defined $orig_result->data();
 
 	foreach my $delay (0, 0.01, 0.1) {

--- a/lib/GenTest/Validator/SelectStability.pm
+++ b/lib/GenTest/Validator/SelectStability.pm
@@ -35,7 +35,7 @@ sub validate {
 	my $orig_result = $results->[0];
 	my $orig_query = $orig_result->query();
 
-        my $is_select = ($orig_query =~ s{/\*.+?\*/}{}sgor) =~ m{^\s*SELECT}sio;
+        my $is_select = is_query_a_select($orig_query);
 	return STATUS_OK if not $is_select;
 	return STATUS_OK if not defined $orig_result->data();
 


### PR DESCRIPTION
Regexp substitues any one or more comments with blank and then asserts if it starts with a SELECT keyword.
Given a query may contain multiple comments, a non-greedy match using ? is exercised for substitution.